### PR TITLE
Update for BluetoothConnector 2.0

### DIFF
--- a/get_devices.py
+++ b/get_devices.py
@@ -4,13 +4,14 @@ import os
 import re
 import json
 
-devicesRaw = os.popen('/bin/bash -c /usr/local/bin/BluetoothConnector').read()
+TRUE, pout = os.popen4('/bin/bash -c /usr/local/bin/BluetoothConnector')
+devicesRaw = pout.read()
 
 deviceMacs = []
 deviceNames = []
 airPodsPosition = -1
 
-macsRegex = r"(?!Usage|Get|\n)^\S*"
+macsRegex = r"^([0-9A-Fa-f]{2}[-]){5}([0-9A-Fa-f]{2})"
 macsMatches = re.finditer(macsRegex, devicesRaw, re.MULTILINE)
 
 for matchNum, match in enumerate(macsMatches, start=1):


### PR DESCRIPTION
As the workflow didn't work for me, I guess due to another Version of BluetoothConnector it couldn't retrieve the device list, I changed it a bit. BluetoothConnector 2.0 gives an error when no argument is provided. So I had to catch the stderr and to change the regex to avoid listing 'Error:' and 'MAC' in deviceMacs. For me it works perfect now.

Should be working with old version as well.